### PR TITLE
Minor fix: At end of animation set compass to exact value

### DIFF
--- a/library/src/main/java/com/redinput/compassview/CompassView.java
+++ b/library/src/main/java/com/redinput/compassview/CompassView.java
@@ -278,6 +278,14 @@ public class CompassView extends View {
                 public void run() {
                     if (Math.abs(mTargetDegrees-mDegrees)<=0.5||Math.abs(mTargetDegrees-mDegrees)>=359.5) {
                         mTimer.cancel();
+                        mDegrees = mTargetDegrees;
+                        mActivity.runOnUiThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                invalidate();
+                                requestLayout();
+                            }
+                        });
                     }else{
                         mDegrees = (mDegrees +360 + mStep) % 360;
                         mActivity.runOnUiThread(new Runnable() {


### PR DESCRIPTION
So far the animation stops when the value differs less than 0.5 degrees from target value.
With this change as a last step the exact value is set.