### PR TITLE
Scale compass height with text size so text does not get cut off

### DIFF
--- a/library/src/main/java/com/redinput/compassview/CompassView.java
+++ b/library/src/main/java/com/redinput/compassview/CompassView.java
@@ -141,7 +141,7 @@ public class CompassView extends View {
         int specMode = MeasureSpec.getMode(measureSpec);
         int specSize = MeasureSpec.getSize(measureSpec);
 
-        int minHeight = (int) Math.floor(30 * getResources().getDisplayMetrics().density);
+        int minHeight = (int) Math.floor(5 * getResources().getDisplayMetrics().density) + (int) (2*mTextSize);
 
         if (specMode == MeasureSpec.EXACTLY) {
             result = specSize;


### PR DESCRIPTION
When using a text size >= 15dp the text is cut off at the top.
With this commit the unitheight is set twice the text size + some margin